### PR TITLE
Display recorded waveform in comparison panel

### DIFF
--- a/components/voice-comparison-panel.tsx
+++ b/components/voice-comparison-panel.tsx
@@ -3,14 +3,22 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Play, Pause, Lock, LogIn } from "lucide-react"
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
+import { WaveformPlayer, type WaveformPlayerHandle } from "@/components/waveform-player"
 import { getAuthStatus } from "@/lib/auth-utils"
 
-export function VoiceComparisonPanel() {
+interface VoiceComparisonPanelProps {
+  myVoiceUrl?: string | null
+  waveformRef?: React.RefObject<WaveformPlayerHandle>
+}
+
+export function VoiceComparisonPanel({ myVoiceUrl, waveformRef }: VoiceComparisonPanelProps) {
   const [playingTrack, setPlayingTrack] = useState<string | null>(null)
   const [isLoggedIn, setIsLoggedIn] = useState(false)
   const [waveformHeights, setWaveformHeights] = useState<{ [key: string]: number[] }>({})
   const [isClient, setIsClient] = useState(false)
+  const internalRef = useRef<WaveformPlayerHandle | null>(null)
+  const playerRef = waveformRef ?? internalRef
 
   useEffect(() => {
     // 클라이언트 마운트 확인
@@ -43,6 +51,12 @@ export function VoiceComparisonPanel() {
     return () => window.removeEventListener('localStorageChange', handleAuthChange)
   }, [])
 
+  useEffect(() => {
+    if (playingTrack !== "my") {
+      playerRef.current?.pause()
+    }
+  }, [playingTrack])
+
   const tracks = [
     { id: "my", label: "내 음성", color: "onair-orange" },
     { id: "ai", label: "AI 예시", color: "onair-mint" },
@@ -50,6 +64,16 @@ export function VoiceComparisonPanel() {
   ]
 
   const handlePlay = (trackId: string) => {
+    if (trackId === "my" && myVoiceUrl) {
+      if (playingTrack === "my") {
+        playerRef.current?.pause()
+        setPlayingTrack(null)
+      } else {
+        playerRef.current?.play()
+        setPlayingTrack("my")
+      }
+      return
+    }
     setPlayingTrack(playingTrack === trackId ? null : trackId)
   }
 
@@ -79,34 +103,38 @@ export function VoiceComparisonPanel() {
             </div>
 
             {/* 음성 파형 시각화 */}
-            <div className="flex items-center space-x-1 h-8 bg-onair-bg rounded p-1">
-              {isClient && waveformHeights[track.id] ? (
-                waveformHeights[track.id].map((height, i) => (
-                  <div
-                    key={i}
-                    className={`bg-${track.color}/60 rounded-full ${playingTrack === track.id ? "animate-wave" : ""}`}
-                    style={{
-                      width: "2px",
-                      height: `${height}px`,
-                      animationDelay: playingTrack === track.id ? `${i * 0.05}s` : "0s",
-                    }}
-                  />
-                ))
-              ) : (
-                // SSR 및 초기 로딩 시 정적 높이 사용
-                Array.from({ length: 60 }).map((_, i) => (
-                  <div
-                    key={i}
-                    className={`bg-${track.color}/60 rounded-full ${playingTrack === track.id ? "animate-wave" : ""}`}
-                    style={{
-                      width: "2px",
-                      height: "15px", // 고정 높이
-                      animationDelay: playingTrack === track.id ? `${i * 0.05}s` : "0s",
-                    }}
-                  />
-                ))
-              )}
-            </div>
+            {track.id === "my" && myVoiceUrl ? (
+              <WaveformPlayer ref={playerRef} url={myVoiceUrl} />
+            ) : (
+              <div className="flex items-center space-x-1 h-8 bg-onair-bg rounded p-1">
+                {isClient && waveformHeights[track.id] ? (
+                  waveformHeights[track.id].map((height, i) => (
+                    <div
+                      key={i}
+                      className={`bg-${track.color}/60 rounded-full ${playingTrack === track.id ? "animate-wave" : ""}`}
+                      style={{
+                        width: "2px",
+                        height: `${height}px`,
+                        animationDelay: playingTrack === track.id ? `${i * 0.05}s` : "0s",
+                      }}
+                    />
+                  ))
+                ) : (
+                  // SSR 및 초기 로딩 시 정적 높이 사용
+                  Array.from({ length: 60 }).map((_, i) => (
+                    <div
+                      key={i}
+                      className={`bg-${track.color}/60 rounded-full ${playingTrack === track.id ? "animate-wave" : ""}`}
+                      style={{
+                        width: "2px",
+                        height: "15px", // 고정 높이
+                        animationDelay: playingTrack === track.id ? `${i * 0.05}s` : "0s",
+                      }}
+                    />
+                  ))
+                )}
+              </div>
+            )}
           </div>
         ))}
 


### PR DESCRIPTION
## Summary
- send recorded audio URL to parent and show waveform in bottom panel
- refactor voice comparison panel to accept my voice audio
- update training tabs to track recording URL and pass to components
- simplify sentence card recording UI

## Testing
- `pnpm lint` *(fails: next command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f90103d6083208545037cded63065