### PR TITLE
Add training record storage feature

### DIFF
--- a/app/api/training-records/route.ts
+++ b/app/api/training-records/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server'
+import clientPromise from '@/lib/mongodb'
+import { ObjectId } from 'mongodb'
+
+export async function GET() {
+  try {
+    const client = await clientPromise
+    const db = client.db('ONAIR')
+    const records = await db
+      .collection('TRAINING_RECORD')
+      .find({})
+      .sort({ createdAt: -1 })
+      .toArray()
+    return NextResponse.json(records)
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch records' }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const client = await clientPromise
+    const db = client.db('ONAIR')
+    const body = await request.json()
+
+    const result = await db.collection('TRAINING_RECORD').insertOne({
+      ...body,
+      createdAt: new Date(),
+    })
+    return NextResponse.json(result)
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to create record' }, { status: 500 })
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const id = searchParams.get('id')
+    if (!id) {
+      return NextResponse.json({ error: 'ID is required' }, { status: 400 })
+    }
+    const client = await clientPromise
+    const db = client.db('ONAIR')
+    const result = await db.collection('TRAINING_RECORD').deleteOne({ _id: new ObjectId(id) })
+    return NextResponse.json(result)
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to delete record' }, { status: 500 })
+  }
+}

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -5,39 +5,27 @@ import { Calendar, TrendingUp, Award, Lock, LogIn, Trash2 } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { useAuth } from "@/hooks/use-auth"
-import { useState } from "react"
-
-const initialTrainingRecords = [
-  {
-    id: 1,
-    date: "2024-01-07",
-    category: "뉴스 읽기",
-    sentence: "오늘 서울 지역에 첫눈이 내렸습니다.",
-    scores: { pronunciation: 91, intonation: 88, tone: 92 },
-    // status: "완료",
-  },
-  {
-    id: 2,
-    date: "2024-01-07",
-    category: "긴 문장",
-    sentence: "정부는 새로운 경제 정책을 발표하며...",
-    scores: { pronunciation: 85, intonation: 82, tone: 89 },
-    // status: "완료",
-  },
-  {
-    id: 3,
-    date: "2024-01-06",
-    category: "짧은 문장",
-    sentence: "안녕하세요, 시청자 여러분.",
-    scores: { pronunciation: 88, intonation: 85, tone: 86 },
-    // status: "완료",
-  },
-];
+import { useState, useEffect } from "react"
 
 export default function HistoryPage() {
   const router = useRouter()
   const { isLoggedIn } = useAuth()
-  const [trainingRecords, setTrainingRecords] = useState(initialTrainingRecords);
+  const [trainingRecords, setTrainingRecords] = useState<any[]>([])
+
+  useEffect(() => {
+    const fetchRecords = async () => {
+      try {
+        const res = await fetch('/api/training-records')
+        if (res.ok) {
+          const data = await res.json()
+          setTrainingRecords(data)
+        }
+      } catch (err) {
+        console.error('Failed to load records', err)
+      }
+    }
+    fetchRecords()
+  }, [])
 
   // 평균 정확도 계산
   const calculateAverageAccuracy = () => {
@@ -90,13 +78,17 @@ export default function HistoryPage() {
   }
 
   // 삭제 핸들러 추가
-  const handleDelete = (id: number) => {
+  const handleDelete = async (id: string) => {
     if (confirm("정말로 이 기록을 삭제하시겠습니까?")) {
-      setTrainingRecords(prevRecords => prevRecords.filter(record => record.id !== id));
-      /* 기록 삭제 완료 알림 */
-      alert("기록이 삭제되었습니다.");
+      try {
+        await fetch(`/api/training-records?id=${id}`, { method: 'DELETE' })
+        setTrainingRecords(prev => prev.filter(record => record._id !== id))
+        alert("기록이 삭제되었습니다.")
+      } catch (err) {
+        console.error('Failed to delete record', err)
+      }
     }
-  };
+  }
 
   return (
     <div className="container mx-auto px-4 py-8 space-y-8">
@@ -163,7 +155,7 @@ export default function HistoryPage() {
               }
 
               return (
-                <div key={item.id} className="p-4 bg-onair-bg rounded-lg border border-onair-text-sub/10 space-y-3">
+                <div key={item._id} className="p-4 bg-onair-bg rounded-lg border border-onair-text-sub/10 space-y-3">
                   {/* 헤더 */}
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
@@ -228,7 +220,7 @@ export default function HistoryPage() {
                     </div>
                     {/* 삭제 버튼 */}
                     <button
-                      onClick={() => handleDelete(item.id)}
+                      onClick={() => handleDelete(item._id)}
                       className="px-3 py-1 text-sm border border-onair-text-sub/20 text-onair-text-sub hover:text-red-400 hover:bg-onair-bg-sub rounded flex items-center gap-1"
                     >
                       <Trash2 className="w-4 h-4" />

--- a/components/ai-result-panel.tsx
+++ b/components/ai-result-panel.tsx
@@ -7,6 +7,13 @@ import { Lock, LogIn } from "lucide-react"
 import { useEffect, useState } from "react"
 import { getAuthStatus } from "@/lib/auth-utils"
 
+export const defaultAIResults = {
+  pronunciation: 85,
+  intonation: 78,
+  tone: 92,
+  stability: 88,
+}
+
 export function AIResultPanel() {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
 
@@ -29,12 +36,7 @@ export function AIResultPanel() {
     return () => window.removeEventListener('localStorageChange', handleAuthChange)
   }, [])
 
-  const results = {
-    pronunciation: 85,
-    intonation: 78,
-    tone: 92,
-    stability: 88,
-  }
+  const results = defaultAIResults
 
   const feedback = [
     { type: "good", text: "전체적인 발음이 명확합니다" },

--- a/components/training-tabs.tsx
+++ b/components/training-tabs.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useRef } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SentenceCard } from "@/components/sentence-card";
-import { AIResultPanel } from "@/components/ai-result-panel";
+import { AIResultPanel, defaultAIResults } from "@/components/ai-result-panel";
 import { VoiceComparisonPanel } from "@/components/voice-comparison-panel";
 import { CustomSentenceUpload } from "@/components/custom-sentence-upload";
 import { PronunciationChallenge } from "@/components/pronunciation-challenge";
@@ -85,6 +85,33 @@ export function TrainingTabs({ initialCustomSentence }: TrainingTabsProps) {
     setHasRecorded(false);
     setMyVoiceUrl(null);
   };
+
+  const handleSaveRecord = async () => {
+    const categories: { [key: string]: string } = {
+      short: '짧은 문장',
+      long: '긴 문장',
+      news: '뉴스 읽기',
+      custom: '내문장 업로드',
+      challenge: '발음 챌린지',
+    }
+    const record = {
+      date: new Date().toISOString().slice(0, 10),
+      category: categories[activeTab],
+      sentence,
+      scores: defaultAIResults,
+      voiceUrl: myVoiceUrl,
+    }
+    try {
+      await fetch('/api/training-records', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(record),
+      })
+      alert('기록이 저장되었습니다.')
+    } catch (err) {
+      console.error('Failed to save record', err)
+    }
+  }
 
   if (loading) return <div className="text-center py-10">문장을 불러오는 중...</div>;
 
@@ -179,6 +206,16 @@ export function TrainingTabs({ initialCustomSentence }: TrainingTabsProps) {
           )}
         </TabsContent>
       </Tabs>
+      {hasRecorded && (
+        <div className="text-center mt-6">
+          <button
+            onClick={handleSaveRecord}
+            className="px-4 py-2 bg-onair-mint text-onair-bg rounded hover:bg-onair-mint/90"
+          >
+            기록 저장
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- export default AI analysis data
- handle record saving in TrainingTabs with new button
- API for creating, listing, and deleting training records
- fetch stored records on history page and allow deletion

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc18129788320b97d623fcb975287