### PR TITLE
Add noise reduction and waveform export

### DIFF
--- a/components/sentence-card.tsx
+++ b/components/sentence-card.tsx
@@ -696,8 +696,11 @@ export function SentenceCard({
       }
 
       const analysisResult = await analysisResponse.json();
-      
+
       console.log("🎯 음성 분석 결과:", analysisResult);
+
+      const processedRefUrl = analysisResult.processed_files?.reference_url || referenceUrl
+      const processedUserUrl = analysisResult.processed_files?.user_url || userRecordingUrl
       
       if (analysisResult.success) {
         console.log("📊 상세 분석 점수:");
@@ -732,7 +735,11 @@ export function SentenceCard({
           
           // 분석 결과를 부모 컴포넌트로 전달
           if (onAnalysisComplete) {
-            onAnalysisComplete(analysisResult.ai_feedback, referenceUrl, userRecordingUrl);
+            onAnalysisComplete(
+              analysisResult.ai_feedback,
+              processedRefUrl,
+              processedUserUrl
+            );
           }
         } else {
           console.log("⚠️ OpenAI 피드백을 받지 못했습니다.");

--- a/server.py
+++ b/server.py
@@ -365,6 +365,15 @@ async def analyze_voice(request: VoiceAnalysisRequest):
         # 음성 분석 실행
         analyzer = Analyzer(temp_ref_path, temp_user_path)
         result = analyzer.run()
+
+        # 노이즈 제거된 음성 파일을 메모리에 저장 후 S3 업로드
+        ref_buf, usr_buf = analyzer.get_processed_audio_buffers()
+        proc_ref_key = f"processed/{uuid.uuid4()}_ref.wav"
+        proc_usr_key = f"processed/{uuid.uuid4()}_usr.wav"
+        s3_client.upload_fileobj(ref_buf, S3_BUCKET_NAME, proc_ref_key, ExtraArgs={"ContentType": "audio/wav"})
+        s3_client.upload_fileobj(usr_buf, S3_BUCKET_NAME, proc_usr_key, ExtraArgs={"ContentType": "audio/wav"})
+        processed_ref_url = f"https://{S3_BUCKET_NAME}.s3.{S3_REGION}.amazonaws.com/{proc_ref_key}"
+        processed_usr_url = f"https://{S3_BUCKET_NAME}.s3.{S3_REGION}.amazonaws.com/{proc_usr_key}"
         
         logger.info("음성 분석 완료")
         logger.info(f"분석 결과: {result}")
@@ -402,6 +411,10 @@ async def analyze_voice(request: VoiceAnalysisRequest):
             "files": {
                 "reference_url": request.reference_url,
                 "user_url": request.user_url
+            },
+            "processed_files": {
+                "reference_url": processed_ref_url,
+                "user_url": processed_usr_url
             }
         }
         


### PR DESCRIPTION
## Summary
- add simple Wiener filter noise reduction in `VoiceAnalyzer`
- export denoised audio buffers
- upload processed audio in `/analyze-voice` endpoint and return URLs
- pass processed audio URLs to frontend so both waveforms use denoised data

## Testing
- `python -m py_compile VoiceAnalyzer.py server.py`
- `npm run lint` *(fails: `next` not found due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6856812d02588320bb955b48425ef4aa